### PR TITLE
Fix missing 'graphql-tag/printer' module

### DIFF
--- a/printer.d.ts
+++ b/printer.d.ts
@@ -1,0 +1,1 @@
+export declare function print(ast: any): string;


### PR DESCRIPTION
Fixes #4 

> TypeScript error: /Users/scott/Documents/showcase/client/node_modules/apollo-client/index.d.ts(3,23): Error TS2307: Cannot find module 'graphql-tag/printer'.

It's not a solution, sort of workaround.