### PR TITLE
create webpack loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ This package only has one feature - it caches previous parse results in a simple
 
 ### Webpack preprocessing
 
-This package also includes a [webpack loader](https://webpack.github.io/docs/loaders.html). There are many benefits over this approach, which saves GraphQL ASTs processing time on client-side, optimizes bundle size and enable queries to be separated from script over `.gql` files.
+This package also includes a [webpack loader](https://webpack.github.io/docs/loaders.html). There are many benefits over this approach, which saves GraphQL ASTs processing time on client-side, optimizes bundle size and enable queries to be separated from script over `.graphql` files.
 
 ```js
 loaders: [
   {
-    test: /\.gql$/,
+    test: /\.(graphql|gql)$/,
     exclude: /node_modules/,
     loader: 'graphql-tag/loader'
   }

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ loaders: [
 then:
 
 ```js
-import query from './query.gql';
+import query from './query.graphql';
 
 console.log(query);
 // {

--- a/README.md
+++ b/README.md
@@ -64,6 +64,31 @@ That's where this package comes in - it lets you write your queries with [ES2015
 
 This package only has one feature - it caches previous parse results in a simple dictionary. This means that if you call the tag on the same query multiple times, it doesn't waste time parsing it again. It also means you can use `===` to compare queries to check if they are identical.
 
+### Webpack preprocessing
+
+This package also includes a [webpack loader](https://webpack.github.io/docs/loaders.html). There are many benefits over this approach, which saves GraphQL ASTs processing time on client-side, optimizes bundle size and enable queries to be separated from script over `.gql` files.
+
+```js
+loaders: [
+  {
+    test: /\.gql$/,
+    exclude: /node_modules/,
+    loader: 'graphql-tag/loader'
+  }
+]
+```
+
+then:
+
+```js
+import query from './query.gql';
+
+console.log(query);
+// {
+//   "kind": "Document",
+// ...
+```
+
 ### Parser and printer
 
 This package also includes two submodules: `graphql-tag/printer` and `graphql-tag/parser`, which are bundled versions of the corresponding modules from the standard `graphql` package. These are included because the `graphql` package currently doesn't build in **React Native**. Use them the same way you would use the relevant modules from `graphql`:

--- a/loader.js
+++ b/loader.js
@@ -1,0 +1,3 @@
+const gql = require('./');
+
+module.exports = source => `module.exports = ${JSON.stringify(gql`${source}`)};`;

--- a/test.js
+++ b/test.js
@@ -1,11 +1,19 @@
-var gqlRequire = require('./index');
-var gqlDefault = require('./index').default;
-var assert = require('chai').assert;
+const gqlRequire = require('./');
+const gqlDefault = require('./').default;
+const loader = require('./loader');
+const assert = require('chai').assert;
 
 [gqlRequire, gqlDefault].forEach((gql, i) => {
   describe(`gql ${i}`, () => {
     it('parses queries', () => {
       assert.equal(gql`{ testQuery }`.kind, 'Document');
+    });
+
+    it('parses queries through webpack loader', () => {
+      const source = loader('{ testQuery }');
+      const ast = JSON.parse(source.replace('module.exports = ', '').slice(0, -1));
+
+      assert.equal(ast.kind, 'Document');
     });
 
     it('returns the same object for the same query', () => {


### PR DESCRIPTION
I was wondering to create another module, but this is a file with 2 lines of code. 😄 

There are many benefits using `graphql-tag` as `webpack` loader:

-  Saves GraphQL ASTs processing on client-side
-  Optimizes bundle size
-  Enable queries to be separated from script over `.gql` files.