### PR TITLE
cache webpack loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This package only has one feature - it caches previous parse results in a simple
 
 ### Webpack preprocessing
 
-This package also includes a [webpack loader](https://webpack.github.io/docs/loaders.html). There are many benefits over this approach, which saves GraphQL ASTs processing time on client-side, optimizes bundle size and enable queries to be separated from script over `.graphql` files.
+This package also includes a [webpack loader](https://webpack.github.io/docs/loaders.html). There are many benefits over this approach, which saves GraphQL ASTs processing time on client-side and enable queries to be separated from script over `.graphql` files.
 
 ```js
 loaders: [

--- a/loader.js
+++ b/loader.js
@@ -1,3 +1,6 @@
 const gql = require('./');
 
-module.exports = source => `module.exports = ${JSON.stringify(gql`${source}`)};`;
+module.exports = function(source) {
+  this.cacheable();
+  return `module.exports = ${JSON.stringify(gql`${source}`)};`;
+};

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ const assert = require('chai').assert;
     });
 
     it('parses queries through webpack loader', () => {
-      const source = loader('{ testQuery }');
+      const source = loader.call({ cacheable() {} }, '{ testQuery }');
       const ast = JSON.parse(source.replace('module.exports = ', '').slice(0, -1));
 
       assert.equal(ast.kind, 'Document');


### PR DESCRIPTION
As per [webpack docs](https://webpack.github.io/docs/how-to-write-a-loader.html#flag-itself-cacheable-if-possible), loaders are better cached, it avoid `.graphql` files to be compiled when changes are not made.