### PR TITLE
De-duplicating fragments in document

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-var assign = require('lodash/assign');
-var uniqBy = require('lodash/uniqBy');
 var parse = require('./parser').parse;
 
 // Strip insignificant whitespace

--- a/index.js
+++ b/index.js
@@ -26,8 +26,8 @@ function resetCaches() {
 // check all fragment definitions, checking for name->source uniqueness
 var printFragmentWarnings = true;
 function checkFragments(ast) {
-  for (var i = 0; i < ast.definitions.length; i++) {
-    var fragmentDefinition = ast.definitions[i];
+  const astFragmentMap = {};
+  ast.definitions = ast.definitions.filter(fragmentDefinition => {
     if (fragmentDefinition.kind === 'FragmentDefinition') {
       var fragmentName = fragmentDefinition.name.value;
       var sourceKey = cacheKeyFromLoc(fragmentDefinition.loc);
@@ -51,7 +51,14 @@ function checkFragments(ast) {
         fragmentSourceMap[fragmentName][sourceKey] = true;
       }
     }
-  }
+
+    if (!astFragmentMap[sourceKey]) {
+      astFragmentMap[sourceKey] = true;
+      return true;
+    } else {
+      return false;
+    }
+  });
 }
 
 function disableFragmentWarnings() {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var assign = require('lodash/assign');
+var uniqBy = require('lodash/uniqBy');
 var parse = require('./parser').parse;
 
 // Strip insignificant whitespace
@@ -28,9 +29,9 @@ function resetCaches() {
 // We also want to make sure only unique fragments exist in the document.
 var printFragmentWarnings = true;
 function checkFragments(ast) {
-  var astFragmentMap = {};
+  for (var i = 0; i < ast.definitions.length; i++) {
+    var fragmentDefinition = ast.definitions[i];
 
-  var uniqueFragmentDefinitions = ast.definitions.filter(fragmentDefinition => {
     if (fragmentDefinition.kind === 'FragmentDefinition') {
       var fragmentName = fragmentDefinition.name.value;
       var sourceKey = cacheKeyFromLoc(fragmentDefinition.loc);
@@ -53,22 +54,11 @@ function checkFragments(ast) {
         fragmentSourceMap[fragmentName] = {};
         fragmentSourceMap[fragmentName][sourceKey] = true;
       }
-
-      if (!astFragmentMap[sourceKey]) {
-        astFragmentMap[sourceKey] = true;
-        return true;
-      } else {
-        // This fragmentDefinition already exists in the AST, no need to add it again.
-        return false;
-      }
-    } else {
-      // This definition is not a fragment.
-      return true;
     }
-  });
+  }
 
   return assign({}, ast, {
-    definitions: uniqueFragmentDefinitions
+    definitions: uniqBy(ast.definitions, (definition) => cacheKeyFromLoc(definition.loc))
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
     "url": "https://github.com/apollostack/graphql-tag/issues"
   },
   "homepage": "https://github.com/apollostack/graphql-tag#readme",
-  "dependencies": {
-    "lodash": "^4.17.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/apollostack/graphql-tag#readme",
   "dependencies": {
-    "lodash": "^4.17.2",
+    "lodash": "^4.17.2"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "url": "https://github.com/apollostack/graphql-tag/issues"
   },
   "homepage": "https://github.com/apollostack/graphql-tag#readme",
-  "dependencies": {},
+  "dependencies": {
+    "lodash": "^4.17.2",
+  },
   "devDependencies": {
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.9.0",

--- a/test.js
+++ b/test.js
@@ -282,6 +282,20 @@ const assert = require('chai').assert;
       });
     });
 
+    describe('fragment de-duplication', () => {
+      beforeEach(() => {
+        gqlRequire.resetCaches();
+      });
+
+      it('strips duplicate fragments from the document', () => {
+        const frag1 = gql`fragment TestDuplicate on Bar { field }`;
+        const query1 = gql`{ bar { fieldOne ...TestDuplicate } } ${frag1} ${frag1}`;
+
+        assert.equal(query1.definitions.length, 2);
+        assert.equal(query1.definitions[1].kind, 'FragmentDefinition')
+      });
+    });
+
     // How to make this work?
     // it.only('can reference a fragment passed as a document via shorthand', () => {
     //   const ast = gql`

--- a/test.js
+++ b/test.js
@@ -282,7 +282,7 @@ const assert = require('chai').assert;
       });
     });
 
-    describe('fragment de-duplication', () => {
+    describe('unique fragments', () => {
       beforeEach(() => {
         gqlRequire.resetCaches();
       });
@@ -290,9 +290,13 @@ const assert = require('chai').assert;
       it('strips duplicate fragments from the document', () => {
         const frag1 = gql`fragment TestDuplicate on Bar { field }`;
         const query1 = gql`{ bar { fieldOne ...TestDuplicate } } ${frag1} ${frag1}`;
+        const query2 = gql`{ bar { fieldOne ...TestDuplicate } } ${frag1}`;
 
         assert.equal(query1.definitions.length, 2);
-        assert.equal(query1.definitions[1].kind, 'FragmentDefinition')
+        assert.equal(query1.definitions[1].kind, 'FragmentDefinition');
+        // We don't test strict equality between the two queries because the source.body parsed from the
+        // document is not the same, but the set of definitions should be.
+        assert.deepEqual(query1.definitions, query2.definitions);
       });
     });
 


### PR DESCRIPTION
Per #27, de-duplicating fragments as we're iterating over them to check for fragment name uniqueness.

This will result in the expression
```js
gql`query { ...SomeFragment } ${SomeFragment} ${SomeFragment}`
```
only emitting one of the fragment definitions
```js
gql`query { ...SomeFragment } fragment SomeFragment on SomeResource { someField }`
```