### PR TITLE
Added ability to "#import" graphql files

### DIFF
--- a/fragment_definition.graphql
+++ b/fragment_definition.graphql
@@ -1,0 +1,4 @@
+fragment authorDetails on Author {
+  firstName
+  lastName
+}

--- a/loader.js
+++ b/loader.js
@@ -8,7 +8,7 @@ function expandImports(source, doc) {
   let outputCode = "";
   
   lines.some((line) => {
-    if (line[0] === '#') {
+    if (line[0] === '#' && line.slice(1).split(' ')[0] === 'import') {
       const importFile = line.slice(1).split(' ')[1];
       const parseDocument = `require(${importFile})`;
       const appendDef = `doc.definitions.append(${parseDocument}.definitions);`;

--- a/loader.js
+++ b/loader.js
@@ -1,6 +1,30 @@
 const gql = require('./');
 
+// Takes `source` (the source GraphQL query string)
+// and `doc` (the parsed GraphQL document) and tacks on
+// the imported definitions.
+function expandImports(source, doc) {
+  const lines = source.split('\n');
+  let outputCode = "";
+  
+  lines.some((line) => {
+    if (line[0] === '#') {
+      const importFile = line.slice(1).split(' ')[1];
+      const parseDocument = `require(${importFile})`;
+      const appendDef = `doc.definitions.append(${parseDocument}.definitions);`;
+      outputCode += appendDef + "\n";
+    }
+    return (line.length !== 0 && line[0] !== '#');
+  });
+
+  return outputCode;
+}
+
 module.exports = function(source) {
   this.cacheable();
-  return `module.exports = ${JSON.stringify(gql`${source}`)};`;
+  const doc = gql`${source}`;
+  const outputCode = `const doc = ${JSON.stringify(doc)};`;
+  const importOutputCode = expandImports(source, doc);
+    
+  return outputCode + "\n" + importOutputCode + "\n" + `module.exports = doc;`;
 };

--- a/test.js
+++ b/test.js
@@ -17,12 +17,27 @@ const assert = require('chai').assert;
     });
 
     it('parses queries through webpack loader', () => {
-      const source = loader.call({ cacheable() {} }, '{ testQuery }');
-      const ast = JSON.parse(source.replace('module.exports = ', '').slice(0, -1));
-
-      assert.equal(ast.kind, 'Document');
+      const jsSource = loader.call({ cacheable() {} }, '{ testQuery }');
+      const module = { exports: undefined };
+      eval(jsSource);
+      assert.equal(module.exports.kind, 'Document');
     });
 
+    it('correctly imports other files through the webpack loader', () => {
+      const query = `#import "./fragment_definition.graphql"
+        query {
+          author {
+            ...authorDetails
+          }
+        }`;
+      const jsSource = loader.call({ cacheable() {} }, query);
+      const lines = jsSource.split('\n');
+      assert.equal(lines.length, 4);
+      assert.include(lines[0], 'const doc =');
+      assert.include(lines[1], 'doc.definitions');
+      assert.include(lines[3], 'module.exports = doc');
+    });                                    
+    
     it('returns the same object for the same query', () => {
       assert.isTrue(gql`{ sameQuery }` === gql`{ sameQuery }`);
     });

--- a/test.js
+++ b/test.js
@@ -36,7 +36,23 @@ const assert = require('chai').assert;
       assert.include(lines[0], 'const doc =');
       assert.include(lines[1], 'doc.definitions');
       assert.include(lines[3], 'module.exports = doc');
-    });                                    
+    });
+
+    it('does not complain when presented with normal comments', (done) => {
+      assert.doesNotThrow(() => {
+        const query = `#normal comment
+          query {
+            author {
+              ...authorDetails
+            }
+          }`;
+        const jsSource = loader.call({ cacheable() {} }, query);
+        const module = { exports: undefined };
+        eval(jsSource);
+        assert.equal(module.exports.kind, 'Document');
+        done();
+      });
+    });
     
     it('returns the same object for the same query', () => {
       assert.isTrue(gql`{ sameQuery }` === gql`{ sameQuery }`);


### PR DESCRIPTION
The goal is to be able to do this with the webpack loader:

```
#import "fragment.graphql"
query {
  author {
    ...authorDetails
  }
}
```
with the following in `fragment.graphql`:

```
fragment authorDetails on Author {
  firstName
  lastName
}
```

This should be equivalent to:

```
query {
  author {
    ...authorDetails
  }
}
fragment authorDetails on Author {
  firstName
  lastName
}
```

in a single file. 
