### PR TITLE
fix loader to output only es5 script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ GraphQL printing and parsing with bundled dependencies. Includes:
 - `gql` A JavaScript template literal tag that parses GraphQL query strings into the standard GraphQL AST.
 - `/parser` A bundled version of `graphql/language/parser`, that builds correctly in React Native.
 - `/printer` A bundled version of `graphql/language/printer`, that builds correctly in React Native.
+- `/loader` A webpack loader to preprocess queries
 
 ### gql
 

--- a/loader.js
+++ b/loader.js
@@ -23,7 +23,7 @@ function expandImports(source, doc) {
 module.exports = function(source) {
   this.cacheable();
   const doc = gql`${source}`;
-  const outputCode = `const doc = ${JSON.stringify(doc)};`;
+  const outputCode = `var doc = ${JSON.stringify(doc)};`;
   const importOutputCode = expandImports(source, doc);
     
   return outputCode + "\n" + importOutputCode + "\n" + `module.exports = doc;`;


### PR DESCRIPTION
After the awesome #33 PR, loader writes es6 code `const` on final bundle.

![screen shot 2017-01-10 at 2 20 03 pm](https://cloud.githubusercontent.com/assets/134727/21821366/46d96920-d741-11e6-9f6d-d14cd60668c4.png)
